### PR TITLE
Don't raise notice when write to btp failed

### DIFF
--- a/src/Btp/Api/Connection.php
+++ b/src/Btp/Api/Connection.php
@@ -144,7 +144,7 @@ class Connection
         $this->connect();
 
         if ($this->socket && !$this->isFailed()) {
-            fwrite(
+            @fwrite(
                 $this->socket,
                 json_encode(array('jsonrpc' => '2.0','method' => $method, 'params' => $params))."\r\n"
             );


### PR DESCRIPTION
When write failed, we get
E_NOTICE: fwrite(): send of 240 bytes failed with errno=111 Connection refused
